### PR TITLE
Fix failing brfs browserify transform

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var fs = require("fs"),
-    path = require("path");
+var fs = require("fs");
+var path = require("path");
 
 module.exports = new Function("d3", fs.readFileSync(path.join(__dirname, "d3.geo.projection.js"), "utf-8"));


### PR DESCRIPTION
Browserify currently fails on this package due to a known issue. See substack/node-browserify/issues/1142 and substack/brfs/issues/28.

We can work around this by breaking up the inline `var` statement.