### PR TITLE
Use 'require' to load the plugin.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,14 @@
-var fs = require("fs"),
-    path = require("path");
+module.exports = function(d3) {
+  // Save pre-existing global.
+  var original = {};
+  if ("d3" in global) original.d3 = global.d3;
 
-module.exports = new Function("d3", fs.readFileSync(path.join(__dirname, "d3.geo.projection.js"), "utf-8"));
+  global.d3 = d3;
+  require("./d3.geo.projection.js");
+
+  // Restore pre-existing global.
+  if ("d3" in original) global.d3 = original.d3; else delete global.d3;
+};
+
+
+

--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
     "name": "Mike Bostock",
     "url": "http://bost.ocks.org/mike"
   },
-  "browserify": {
-    "transform": ["brfs"]
-  },
   "contributors": [
     {
       "name": "Jason Davies",
@@ -41,8 +38,5 @@
       "type": "BSD",
       "url": "https://github.com/d3/d3-geo-projection/blob/master/LICENSE"
     }
-  ],
-  "dependencies": {
-    "brfs": "^1.3.0"
-  }
+  ]
 }


### PR DESCRIPTION
This approach avoids filename manipulation and manual loading using readFileSync. It also produces minifiable output when run through browserify and eliminates the need for the brfs dependency (introduced in #15). However, because the plugin requires a global d3 instance, we must take care to swap out and subsequently restore any existing global called "d3".