### PR TITLE
add .lobes() to interrupted projections

### DIFF
--- a/src/interrupted/index.js
+++ b/src/interrupted/index.js
@@ -101,44 +101,44 @@ export default function(project, lobes) {
   };
   
   p.lobes = function(_) {
-    if (arguments.length) {
-      lobes = _;
-      sphere = interpolateSphere(lobes);
-      lobes = lobes.map(function(lobe) {
-        return lobe.map(function(l) {
-          return [
-            [l[0][0] * radians, l[0][1] * radians],
-            [l[1][0] * radians, l[1][1] * radians],
-            [l[2][0] * radians, l[2][1] * radians]
-          ];
-        });
+    if (!arguments.length) return lobes.map(function(lobe) {
+      return lobe.map(function(l) {
+        return [
+          [l[0][0] * degrees, l[0][1] * degrees],
+          [l[1][0] * degrees, l[1][1] * degrees],
+          [l[2][0] * degrees, l[2][1] * degrees]
+        ];
       });
-      bounds = lobes.map(function(lobe) {
-        return lobe.map(function(l) {
-          var x0 = project(l[0][0], l[0][1])[0],
-              x1 = project(l[2][0], l[2][1])[0],
-              y0 = project(l[1][0], l[0][1])[1],
-              y1 = project(l[1][0], l[1][1])[1],
-              t;
-          if (y0 > y1) t = y0, y0 = y1, y1 = t;
-          return [[x0, y0], [x1, y1]];
-        });
-      });
-      return p;
-    } else {
-      return lobes.map(function(lobe) {
-        return lobe.map(function(l) {
-          return [
-            [l[0][0] * degrees, l[0][1] * degrees],
-            [l[1][0] * degrees, l[1][1] * degrees],
-            [l[2][0] * degrees, l[2][1] * degrees]
-          ];
-        });
-      });
-    }
-  }
+    });
 
-  if (lobes) p.lobes(lobes);
+    sphere = interpolateSphere(_);
+
+    lobes = _.map(function(lobe) {
+      return lobe.map(function(l) {
+        return [
+          [l[0][0] * radians, l[0][1] * radians],
+          [l[1][0] * radians, l[1][1] * radians],
+          [l[2][0] * radians, l[2][1] * radians]
+        ];
+      });
+    });
+
+    bounds = lobes.map(function(lobe) {
+      return lobe.map(function(l) {
+        var x0 = project(l[0][0], l[0][1])[0],
+            x1 = project(l[2][0], l[2][1])[0],
+            y0 = project(l[1][0], l[0][1])[1],
+            y1 = project(l[1][0], l[1][1])[1],
+            t;
+        if (y0 > y1) t = y0, y0 = y1, y1 = t;
+        return [[x0, y0], [x1, y1]];
+      });
+    });
+
+    return p;
+  };
+
+  if (lobes != null) p.lobes(lobes);
 
   return p;
 }


### PR DESCRIPTION
When playing with [Oceans-centric Interrupted](https://bl.ocks.org/Fil/1ba3e1169472cf9cd59c1e855e05ac62) [projections](https://bl.ocks.org/Fil/d90a94d7333bfef753e92a4abb7611b4) I was frustrated that `geoInterruptedMollweide` and the like didn't offer a way to read the lobes.

This PR adds a `.lobes()` method that allows getting and setting the lobes. It's really just syntactic sugar.

If you like it I will add documentation & tests.