### PR TITLE
geoquantize (#122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1070,6 +1070,17 @@ The required *module* is resolved relative to the [current working directory](ht
 
 Multiple modules can be required by repeating this option.
 
+### geoquantize
+
+<a href="#geoquantize" name="geoquantize">#</a> <b>geoquantize</b> [<i>options</i>…] [<i>file</i>] [<>](https://github.com/d3/d3-geo-projection/blob/master/bin/geoquantize "Source")
+
+Reads the GeoJSON object from the specified input *file* and outputs a new GeoJSON *object* with coordinates reduced to *precision*. Same options as [geoproject](#geoproject).
+
+```bash
+geoquantize us.json --precision 3 \
+  > us-quantized.json
+```
+
 ### geostitch
 
 <a href="#geostitch" name="geostitch">#</a> <b>geostitch</b> [<i>options</i>…] [<i>file</i>] [<>](https://github.com/d3/d3-geo-projection/blob/master/bin/geostitch "Source")

--- a/bin/geoquantize
+++ b/bin/geoquantize
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 var commander = require("commander"),
-    vm = require("vm"),
     d3 = Object.assign({}, require("d3-geo"), require("../")),
     read = require("./read"),
     write = require("./write");
@@ -9,7 +8,7 @@ var commander = require("commander"),
 commander
     .version(require("../package.json").version)
     .usage("[options] [file]")
-    .description("Transform GeoJSON, such as to project from spherical to planar coordinates.")
+    .description("Quantize GeoJSON.")
     .option("-o, --out <file>", "output file name; defaults to “-” for stdout", "-")
     .option("-p, --precision <value>", "number of output digits after the decimal point")
     .option("-n, --newline-delimited", "use newline-delimited JSON")
@@ -24,13 +23,10 @@ if (commander.args.length > 1) {
   commander.args.push("-");
 }
 
-var sandbox = {d3: d3, d: undefined, i: -1},
-    context = new vm.createContext(sandbox),
-    reader = read(commander.args[0], commander.newlineDelimited, quantize).then(end).catch(abort),
+var reader = read(commander.args[0], commander.newlineDelimited, quantize).then(end).catch(abort),
     writer = write(commander.out);
 
 function quantize(d, i) {
-  sandbox.d = d, sandbox.i = i;
   if (commander.precision != null) d = d3.geoQuantize(d, commander.precision);
   return writer.write(JSON.stringify(d) + "\n");
 }

--- a/bin/geoquantize
+++ b/bin/geoquantize
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+var commander = require("commander"),
+    vm = require("vm"),
+    d3 = Object.assign({}, require("d3-geo"), require("../")),
+    read = require("./read"),
+    write = require("./write");
+
+commander
+    .version(require("../package.json").version)
+    .usage("[options] [file]")
+    .description("Transform GeoJSON, such as to project from spherical to planar coordinates.")
+    .option("-o, --out <file>", "output file name; defaults to “-” for stdout", "-")
+    .option("-p, --precision <value>", "number of output digits after the decimal point")
+    .option("-n, --newline-delimited", "use newline-delimited JSON")
+    .parse(process.argv);
+
+if (commander.args.length > 1) {
+  console.error();
+  console.error("  error: multiple input files");
+  console.error();
+  process.exit(1);
+} else if (commander.args.length === 0) {
+  commander.args.push("-");
+}
+
+var sandbox = {d3: d3, d: undefined, i: -1},
+    context = new vm.createContext(sandbox),
+    reader = read(commander.args[0], commander.newlineDelimited, quantize).then(end).catch(abort),
+    writer = write(commander.out);
+
+function quantize(d, i) {
+  sandbox.d = d, sandbox.i = i;
+  if (commander.precision != null) d = d3.geoQuantize(d, commander.precision);
+  return writer.write(JSON.stringify(d) + "\n");
+}
+
+function end() {
+  return writer.end();
+}
+
+function abort(error) {
+  console.error(error.stack);
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "geo2svg": "bin/geo2svg",
     "geograticule": "bin/geograticule",
     "geoproject": "bin/geoproject",
+    "geoquantize": "bin/geoquantize",
     "geostitch": "bin/geostitch"
   },
   "scripts": {


### PR DESCRIPTION
We _do_ need geoquantize as a separate script if we want to quantize spherical GeoJSON.

TL;DR:
`geoproject 'd3.geoIdentity()' -p 3` does not work properly because geoproject reorders the projected polygons+holes based on their _planar_ coordinates, but this is the case where the output is in spherical coordinates and the polygons should not be reordered (at all), or, if we want to reorder them, not based on the test in src/project/clockwise.js (which is testing winding order for planar polygons).

To test, just project South Africa with the hole around Lesotho.

(Cleaned up the mess in PR #140.)