### PR TITLE
restore bertin1953 rotate

### DIFF
--- a/src/bertin.js
+++ b/src/bertin.js
@@ -32,12 +32,9 @@ export function bertin1953Raw() {
 }
 
 export default function() {
-  var p = projection(bertin1953Raw());
-
-  p.rotate([-16.5, -42]);
-  delete p.rotate;
-
-  return p
+  // this projection should not be rotated
+  return projection(bertin1953Raw())
+    .rotate([-16.5, -42])
     .scale(176.57)
     .center([7.93, 0.09]);
 }


### PR DESCRIPTION
removing rotate() was a mistake: it's doing more harm than good, as it breaks some scripts which expect all projections to be rotatable, and forbids reading the rotate params

and it precludes us from experimenting