### PR TITLE
Allow spherical winding of polygons in geoProject.

### DIFF
--- a/README.md
+++ b/README.md
@@ -920,9 +920,9 @@ The Peirce quincuncial projection is the quincuncial form of the [Guyou projecti
 
 ### Transformations
 
-<a href="#geoProject" name="geoProject">#</a> d3.<b>geoProject</b>(<i>object</i>, <i>projection</i>) · [Source](https://github.com/d3/d3-geo-projection/blob/master/src/project/index.js)
+<a href="#geoProject" name="geoProject">#</a> d3.<b>geoProject</b>(<i>object</i>, <i>projection</i>[, <i>spherical</i>]) · [Source](https://github.com/d3/d3-geo-projection/blob/master/src/project/index.js)
 
-Projects the specified GeoJSON *object* using the specified *projection*, returning a shallow copy of the specified GeoJSON *object* with projected coordinates. Typically, the input coordinates are spherical and the output coordinates are planar, but the *projection* can also be an [arbitrary geometric transformation](https://github.com/d3/d3-geo/blob/master/README.md#transforms).
+Projects the specified GeoJSON *object* using the specified *projection*, returning a shallow copy of the specified GeoJSON *object* with projected coordinates. Typically, the input coordinates are spherical and the output coordinates are planar, but the *projection* can be an [arbitrary geometric transformation](https://github.com/d3/d3-geo/blob/master/README.md#transforms). If *spherical* is true, the projected coordinates are considered to be in spherical coordinates, and the appropriate algorithm for polygon winding is applied.
 
 See also [geoproject](#geoproject).
 

--- a/test/project-test.js
+++ b/test/project-test.js
@@ -1,0 +1,82 @@
+var tape = require("tape"),
+    d3 = require("../"),
+    d3Geo = require("d3-geo");
+
+require("./inDelta");
+
+tape("project(Geometry, transform) rewinds planar polygons", function(test) {
+  var projection = d3Geo.geoEquirectangular().translate([0,0]).scale(180/Math.PI);
+  var poly = {
+    type: "Polygon",
+    coordinates: [
+      [ [1,1], [1,10], [10,10], [10,1], [1,1] ],
+      [ [3,3], [9,3], [9,9], [3,9], [3,3] ]
+    ]
+  };
+  test.inDelta(d3.geoProject(poly, projection).coordinates,
+    [
+      [ [1,-1], [1,-10], [10,-10], [10,-1], [1,-1] ],
+      [ [3,-3], [9,-3], [9,-9], [3,-9], [3,-3] ]
+    ]);
+  test.equal(d3.geoProject(poly, projection).type, "Polygon");
+
+  // badly formed multipolygon
+  poly = {
+    type: "MultiPolygon",
+    coordinates: [
+      [[ [1,1], [1,10], [10,10], [10,1], [1,1] ]],
+      [[ [3,3], [3,9], [9,9], [9,3], [3,3] ]]
+    ]
+  };
+  test.inDelta(d3.geoProject(poly, projection).coordinates,
+    [
+      [[ [1,-1], [1,-10], [10,-10], [10,-1], [1,-1] ]],
+      [[ [3,-3], [3,-9], [9,-9], [9,-3], [3,-3] ]]
+    ]);
+  test.equal(d3.geoProject(poly, projection).type, "MultiPolygon");
+  test.end();
+});
+
+
+tape("project(Geometry, transform, true) rewinds spherical polygons", function(test) {
+  var transformRotate = d3Geo.geoTransform({
+    point: function (x, y) { this.stream.point(x + 10,y); }
+  });
+
+  var poly = {
+    type: "Polygon",
+    coordinates: [
+      [ [1,1], [1,10], [10,10], [10,1], [1,1] ],
+      [ [3,3], [9,3], [9,9], [3,9], [3,3] ]
+    ]
+  };
+  test.inDelta(d3.geoProject(poly, transformRotate, true).coordinates,
+    [
+      [ [11,1], [11,10], [20,10], [20,1], [11,1] ],
+      [ [13,3], [19,3], [19,9], [13,9], [13,3] ]
+    ]);
+  test.equal(d3.geoProject(poly, transformRotate, true).type, "Polygon");
+
+  // the transform would fail if we didn't specify spherical=true
+  test.equal(d3.geoProject(poly, transformRotate, false).type, "MultiPolygon");
+
+  // badly formed multipolygon
+  poly = {
+    type: "MultiPolygon",
+    coordinates: [
+      [[ [1,1], [1,10], [10,10], [10,1], [1,1] ]],
+      [[ [3,3], [3,9], [9,9], [9,3], [3,3] ]]
+    ]
+  };
+  test.inDelta(d3.geoProject(poly, transformRotate, true).coordinates,
+    [
+      [[ [11,1], [11,10], [20,10], [20,1], [11,1] ]],
+      [[ [13,3], [13,9], [19,9], [19,3], [13,3] ]]
+    ]);
+  test.equal(d3.geoProject(poly, transformRotate, true).type, "MultiPolygon");
+  
+  // the transform would fail if we didn't specify spherical=true
+  test.equal(d3.geoProject(poly, transformRotate, false).type, "Polygon");
+
+  test.end();
+});


### PR DESCRIPTION
Context: geoProject rewinds polygons to put them in the correct order as [outer ring, …holes], creating MultiPolygons as necessary. This is the desired (and semi-documented) behavior, however it precludes using geoProject with transforms that map spherical geometries to the sphere.

This change allows to specify, with an optional *spherical* boolean flag, that the transform returns spherical coordinates. We can then call the relevant polygon winding algorithms: geoContains and a test on geoArea replace the planar contains and clockwise functions to determine is a ring is an outer ring or a hole.

For clarity, the change is kept minimal in this commit, but before we merge I will reformat it (whitespace).

An older tentative was at: https://github.com/d3/d3-geo-projection/pull/146